### PR TITLE
fix(plugins): write downloaded plugins to per-plugin dir instead of literal "{plugin_name}"

### DIFF
--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -88,7 +88,7 @@ async fn download_and_write_file(
 
   let mut stream = response.bytes_stream();
   let plugins_dir = app_data_dir.join("plugins");
-  let plugin_name_dir = plugins_dir.join("{plugin_name}");
+  let plugin_name_dir = plugins_dir.join(&plugin_name);
   fs::create_dir_all(plugin_name_dir.clone()).await?;
   let file_path = plugin_name_dir.join(format!("{}.wasm", &plugin_name));
   let mut file = File::create(file_path).await?;


### PR DESCRIPTION
## Problem

In `src-tauri/src/rpc.rs`, `download_and_write_file` builds the destination directory like this:

```rust
let plugins_dir = app_data_dir.join("plugins");
let plugin_name_dir = plugins_dir.join("{plugin_name}"); // <-- literal string
fs::create_dir_all(plugin_name_dir.clone()).await?;
let file_path = plugin_name_dir.join(format!("{}.wasm", &plugin_name));
```

`"{plugin_name}"` is a plain string literal — the `format!` interpolation was never applied. As a result every downloaded plugin (on both `Install` and `Update` events) is written into a single folder named literally `{plugin_name}`, i.e. `plugins/{plugin_name}/<name>.wasm`.

The WASM loader in `plugins.rs` resolves components at:

```rust
let plugin_absolute_path = plugin_dir
  .join(&plugin_name)
  .join(plugin_name)
  .with_extension("wasm"); // plugins/<name>/<name>.wasm
```

So freshly installed/updated plugins are never found at the path the loader expects, and plugin install/update is effectively broken.

## Fix

Interpolate the real plugin name so files land at the expected `plugins/<name>/<name>.wasm`:

```rust
let plugin_name_dir = plugins_dir.join(&plugin_name);
```

One-line, behaviour-only change; no formatting impact.

## Notes for maintainers (out of scope here)

While reviewing I noticed a couple of related inconsistencies around the same plugin layout that you may want to look at separately:

- `EventType::Delete` removes `plugins/<name>.wasm` (flat), which doesn't match the per-directory layout written on install (`plugins/<name>/<name>.wasm`).
- `get_list_plugins_with_versions` only scans top-level `plugins/*.wasm` files and doesn't descend into the per-plugin subdirectories, so it won't report versions for plugins stored as `plugins/<name>/<name>.wasm`.

Happy to follow up on those in a separate PR if useful.