### PR TITLE
fix(updater): avoid panics on invalid versions and task/emit failures

### DIFF
--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -88,43 +88,47 @@ async fn run_task<R: Runtime>(task: Task<R>) {
       goal_version,
       response,
     } => {
+      let goal_version = match goal_version.map(CleanName::new).transpose() {
+        Ok(goal) => goal,
+        Err(invalid) => {
+          let _ = response.send(Err(SparusError::Update(format!(
+            "invalid goal version: {invalid}"
+          ))));
+          return;
+        }
+      };
+
       let result = workspace
         .lock()
         .await
-        .update(
-          &repo,
-          goal_version.map(|v| CleanName::new(v).unwrap()),
-          UpdateOptions::default(),
-        )
+        .update(&repo, goal_version, UpdateOptions::default())
         .try_take_while(|progress| {
           let state = progress.borrow();
           let progression = state.histogram.progress();
           let speed = state.histogram.speed().progress_per_sec();
-          window
-            .emit(
-              "sparus://downloadinfos",
-              DownloadInfos {
-                packages_start: state.downloading_package_idx,
-                packages_end: state.steps.len(),
-                downloaded_files_start: Some(progression.downloaded_files),
-                downloaded_files_end: Some(state.download_files),
-                downloaded_bytes_start: Some(progression.downloaded_bytes),
-                downloaded_bytes_end: Some(state.download_bytes),
-                applied_files_start: Some(progression.applied_files),
-                applied_files_end: Some(state.apply_files),
-                applied_input_bytes_start: Some(progression.applied_input_bytes),
-                applied_input_bytes_end: Some(state.apply_input_bytes),
-                applied_output_bytes_start: Some(progression.applied_output_bytes),
-                applied_output_bytes_end: Some(state.apply_output_bytes),
-                failed_files: Some(progression.failed_files),
-                downloaded_files_per_sec: Some(speed.downloaded_files_per_sec),
-                downloaded_bytes_per_sec: Some(speed.downloaded_bytes_per_sec),
-                applied_files_per_sec: Some(speed.applied_files_per_sec),
-                applied_input_bytes_per_sec: Some(speed.applied_input_bytes_per_sec),
-                applied_output_bytes_per_sec: Some(speed.applied_output_bytes_per_sec),
-              },
-            )
-            .unwrap();
+          let _ = window.emit(
+            "sparus://downloadinfos",
+            DownloadInfos {
+              packages_start: state.downloading_package_idx,
+              packages_end: state.steps.len(),
+              downloaded_files_start: Some(progression.downloaded_files),
+              downloaded_files_end: Some(state.download_files),
+              downloaded_bytes_start: Some(progression.downloaded_bytes),
+              downloaded_bytes_end: Some(state.download_bytes),
+              applied_files_start: Some(progression.applied_files),
+              applied_files_end: Some(state.apply_files),
+              applied_input_bytes_start: Some(progression.applied_input_bytes),
+              applied_input_bytes_end: Some(state.apply_input_bytes),
+              applied_output_bytes_start: Some(progression.applied_output_bytes),
+              applied_output_bytes_end: Some(state.apply_output_bytes),
+              failed_files: Some(progression.failed_files),
+              downloaded_files_per_sec: Some(speed.downloaded_files_per_sec),
+              downloaded_bytes_per_sec: Some(speed.downloaded_bytes_per_sec),
+              applied_files_per_sec: Some(speed.applied_files_per_sec),
+              applied_input_bytes_per_sec: Some(speed.applied_input_bytes_per_sec),
+              applied_output_bytes_per_sec: Some(speed.applied_output_bytes_per_sec),
+            },
+          );
           future::ready(Ok(true))
         })
         .try_for_each(|_| future::ready(Ok(())))
@@ -156,7 +160,12 @@ pub async fn update_workspace<R: Runtime>(
     goal_version,
     response: send,
   });
-  response.await.unwrap()
+  match response.await {
+    Ok(result) => result,
+    Err(_) => Err(SparusError::Update(
+      "update task did not return a result".to_string(),
+    )),
+  }
 }
 
 #[command]
@@ -176,7 +185,7 @@ pub async fn update_available<R: Runtime>(
   }
 
   let local_version_string = utils::version(handle)?;
-  let local_version = Version::parse(&local_version_string).unwrap();
+  let local_version = Version::parse(&local_version_string)?;
   let remote_version = latest_remote_version(repository_url, auth).await;
   match remote_version {
     Ok(value) => {


### PR DESCRIPTION
## Problem

The updater relied on several `.unwrap()` calls that turn recoverable conditions into hard panics (the project even has a recent commit, *"don't panic if there is no version"*, showing this is a known concern):

- **`Version::parse(local_version).unwrap()`** — panics when the locally stored version string is not valid semver.
- **`CleanName::new(goal_version).unwrap()`** — panics when a caller requests a goal version containing characters outside `[A-Za-z0-9._-]` (`CleanName::new` returns `Err` for those).
- **`window.emit(...).unwrap()`** — panics the update worker if a progress event can't be emitted (e.g. the window was closed mid-update), aborting an otherwise healthy download.
- **`response.await.unwrap()`** — panics the `update_workspace` command if the worker thread dropped the response channel.

## Fix

- Propagate the semver parse error as a `SparusError` (`?`).
- Validate the goal version up front and report failures through the task's response channel.
- Ignore the result of the progress `emit` so a dropped event doesn't abort the update.
- Return a `SparusError` instead of panicking when the worker channel is closed.

Behaviour is unchanged on the happy path; only the failure modes go from *panic* to *surfaced error*. `cargo fmt`-clean.

> Note: CI `fmt` is currently red on `main` due to a pre-existing formatting issue in `plugins.rs` unrelated to this change (see separate style PR).