### PR TITLE
style: fix rustfmt formatting in plugins.rs

### DIFF
--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -31,8 +31,7 @@ pub struct PluginSystem {
 impl PluginSystem {
   pub fn new() -> Self {
     let mut config = Config::new();
-    config
-      .wasm_component_model_async(true);
+    config.wasm_component_model_async(true);
     let engine =
       Engine::new(&config).unwrap_or_else(|err| panic!("Unable to start wasm runtime: {}", err));
     Self { engine }


### PR DESCRIPTION
## Problem

The Build workflow runs `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`, and it currently **fails on `main`**: `PluginSystem::new` contains a single-call method chain that rustfmt wants collapsed onto one line:

```rust
config
  .wasm_component_model_async(true);
```

(Likely a leftover from when the chain had more than one call.) Because of this the `fmt` step is red on every recent `main` build.

## Fix

Run `cargo fmt`:

```rust
config.wasm_component_model_async(true);
```

One-line, no behaviour change — just unblocks the formatting check so the rest of the build can be evaluated. Helps the other open fix PRs show a green `fmt` step too.