### PR TITLE
fix(config): load bundled Sparus.json from the resource dir on desktop

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,34 +53,24 @@ pub fn run_app<R: Runtime>(mut builder: Builder<R>) {
         .app_data_dir()
         .expect("Unable to access to config directory");
       let store_file_destination = app_data_dir.join(config_file);
+      let config_path = match app.path().resource_dir() {
+        Ok(dir) => {
+          let bundled = dir.join(config_file);
+          if bundled.is_file() {
+            bundled
+          } else {
+            PathBuf::from(config_file)
+          }
+        }
+        Err(_) => PathBuf::from(config_file),
+      };
+      store_file_content = fs::read_to_string(&config_path).unwrap();
 
       #[cfg(mobile)]
-      {
-        let resource_dir_file = app
-          .path()
-          .resource_dir()
-          .expect("Unable to access to resource directory")
-          .join(config_file);
-        store_file_content = app.fs().read_to_string(&resource_dir_file)?;
-        WebviewWindowBuilder::new(app, "main", WebviewUrl::default()).build()?;
-      }
+      WebviewWindowBuilder::new(app, "main", WebviewUrl::default()).build()?;
 
       #[cfg(desktop)]
       {
-        // In a bundled build `Sparus.json` ships as a resource; in `tauri dev`
-        // it lives next to the binary's working directory (see README). Prefer
-        // the bundled resource and fall back to the working directory.
-        let bundled_config = app
-          .path()
-          .resource_dir()
-          .map(|dir| dir.join(config_file))
-          .ok()
-          .filter(|path| path.is_file());
-        store_file_content = match bundled_config {
-          Some(path) => fs::read_to_string(path)?,
-          None => fs::read_to_string(config_file)?,
-        };
-
         WebviewWindowBuilder::new(app, "main", Default::default())
           .inner_size(800., 600.)
           .title("Sparus")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,7 +67,19 @@ pub fn run_app<R: Runtime>(mut builder: Builder<R>) {
 
       #[cfg(desktop)]
       {
-        store_file_content = fs::read_to_string(config_file)?;
+        // In a bundled build `Sparus.json` ships as a resource; in `tauri dev`
+        // it lives next to the binary's working directory (see README). Prefer
+        // the bundled resource and fall back to the working directory.
+        let bundled_config = app
+          .path()
+          .resource_dir()
+          .map(|dir| dir.join(config_file))
+          .ok()
+          .filter(|path| path.is_file());
+        store_file_content = match bundled_config {
+          Some(path) => fs::read_to_string(path)?,
+          None => fs::read_to_string(config_file)?,
+        };
 
         WebviewWindowBuilder::new(app, "main", Default::default())
           .inner_size(800., 600.)


### PR DESCRIPTION
## Problem

On desktop, the default config is read like this in `run_app`'s `setup`:

```rust
#[cfg(desktop)]
{
  store_file_content = fs::read_to_string(config_file)?; // config_file = "Sparus.json"
  ...
}
```

`"Sparus.json"` is resolved relative to the **process working directory**. That happens to work under `tauri dev` (cwd is `src-tauri`, where the README tells you to put `Sparus.json`), but in a packaged build the working directory is wherever the app was launched from, so the file isn't found and the first-launch store seeding (`fs::write(&store_file_destination, &store_file_content)`) fails.

Meanwhile the mobile branch already reads the config from `resource_dir()`, and `Sparus.json` is declared as a bundle resource in `tauri.conf.json`:

```json
"resources": { "Sparus.json": "Sparus.json" }
```

## Fix

Read the bundled resource from `resource_dir()` on desktop too, and fall back to the working-directory path so the documented `tauri dev` workflow keeps working:

```rust
let bundled_config = app
  .path()
  .resource_dir()
  .map(|dir| dir.join(config_file))
  .ok()
  .filter(|path| path.is_file());
store_file_content = match bundled_config {
  Some(path) => fs::read_to_string(path)?,
  None => fs::read_to_string(config_file)?,
};
```

This fixes packaged builds without changing dev behaviour. `cargo fmt`-clean.

> I wasn't able to run a full packaged build to confirm end-to-end (heavy git deps + protoc), so a quick check on your side that `resource_dir()` resolves as expected on your target would be appreciated.