### PR TITLE
fix(ui): split SparusError value type from context type (fixes #1024)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import DesktopBackground from "assets/DesktopBackground.jpg";
 import { SparusErrorContext, StoreProvider } from "utils/Context";
 import { PluginManager } from "components/PluginsManager";
 
-import type { SparusError } from "utils/Context";
+import type { SparusError, SparusErrorContextType } from "utils/Context";
 
 function App() {
   const [globalError, setGlobalError] = useState<SparusError>();
@@ -19,12 +19,12 @@ function App() {
   const DesktopRouting = useRoutes(DesktopRoutes);
   const MobileRouting = useRoutes(MobileRoutes);
 
-  const errorCache = useMemo(
+  const errorCache = useMemo<SparusErrorContextType>(
     () => ({
       globalError,
-      setGlobalError,
+      setGlobalError: (err: unknown) => setGlobalError(err as SparusError),
     }),
-    [globalError, setGlobalError],
+    [globalError],
   );
 
   useEffect(() => {

--- a/src/utils/Context.tsx
+++ b/src/utils/Context.tsx
@@ -2,16 +2,16 @@ import { ReactNode, createContext } from "react";
 import { LazyStore } from "@tauri-apps/plugin-store";
 
 export interface SparusError {
-  globalError:
-    | {
-        kind: string;
-        message: string;
-      }
-    | undefined;
+  kind: string;
+  message: string;
+}
+
+export interface SparusErrorContextType {
+  globalError: SparusError | undefined;
   setGlobalError: (err: unknown) => void;
 }
 
-const SparusErrorContext = createContext<SparusError>({
+const SparusErrorContext = createContext<SparusErrorContextType>({
   globalError: undefined,
   setGlobalError: () => undefined,
 });


### PR DESCRIPTION
Fixes #1024.

## Problem

`App.tsx` built the error context provider value from `useState<SparusError>()`, but the imported `SparusError` actually described the **context shape** (it bundled `globalError` + `setGlobalError`). So the provider value didn't match the context type:

```
src/App.tsx(45,34): error TS2322: Type '{ globalError: SparusError | undefined;
setGlobalError: React.Dispatch<React.SetStateAction<SparusError | undefined>>; }'
is not assignable to type 'SparusError'.
```

## Fix

Separate the two concepts in `utils/Context.tsx`:

- `SparusError` is now the **error value**: `{ kind: string; message: string }`.
- `SparusErrorContextType` is the **context shape**: `{ globalError: SparusError | undefined; setGlobalError: (err: unknown) => void }`.

`App.tsx` now stores the error value (`useState<SparusError>()`) and exposes `setGlobalError` as `(err: unknown) => void` through a thin wrapper.

## Why the wrapper / why consumers are safe

All five consumers (`Footer`, `Options`, `Header`, `Plugins`, `PluginsManager`) import only the `SparusErrorContext` **value** and call `setGlobalError(...)` with heterogeneous args — strings, `null`, and caught `unknown` errors. Keeping the setter typed `(err: unknown) => void` means none of them need to change and runtime behaviour is identical (the cast is erased; the wrapper forwards the same value to React's state setter). `Footer`/`Options` keep their own local `interface SparusError { kind; message }`, unchanged.

## Verification

- The original code reproduces `TS2322` exactly.
- After the change: `tsc --noEmit` exits 0 and `vp lint` reports no errors.

_Note (out of scope): a few call sites pass plain strings to `setGlobalError` while `Footer` reads `globalError.kind/.message` — a pre-existing string-vs-object inconsistency that predates this change and isn't touched here._