### PR TITLE
fix(build): resolve TS2321/TS2769 in vite.config.ts plugins (fixes #1025)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite-plus";
+import { defineConfig, type PluginOption } from "vite-plus";
 import react from "@vitejs/plugin-react";
 
 const host = process.env.TAURI_DEV_HOST;
@@ -7,7 +7,11 @@ export default defineConfig({
   define: {
     process: { env: {} },
   },
-  plugins: [react()],
+  // `react()` returns Plugin[]; the spread flattens it (a nested [react()] is
+  // Plugin[][] and trips TS2769). The `as PluginOption[]` is load-bearing: it
+  // gives `plugins` the exact expected type so vp lint's type check does not
+  // overflow comparing the config to UserConfig (TS2321 "Excessive stack depth").
+  plugins: [...react()] as PluginOption[],
   resolve: {
     tsconfigPaths: true,
   },


### PR DESCRIPTION
Fixes #1025.

## Problem

`@vitejs/plugin-react`'s `react()` returns `Plugin[]`, so `plugins: [react()]` was a nested `Plugin[][]`. That produced:

```
vite.config.ts:10  TS2769: No overload matches this call
vite.config.ts:6   TS2321: Excessive stack depth comparing types '{ ...; plugins: Plugin<any>[][]; ... }' and 'UserConfig'
```

## Fix

```ts
import { defineConfig, type PluginOption } from "vite-plus";
...
plugins: [...react()] as PluginOption[],
```

- The **spread** flattens `Plugin[][]` → `Plugin[]` (Vite flattens nested plugin arrays at runtime anyway, so behaviour is unchanged). This alone clears `TS2769`.
- The **`as PluginOption[]`** gives `plugins` the exact type `UserConfig` expects, which short-circuits the deep structural comparison that overflowed (`TS2321`).

## Why the cast is load-bearing (please don't drop it)

The `TS2321` error comes from `vp lint` (the config enables `typeAware`/`typeCheck`/`denyWarnings`), **not** from `tsc` — `tsc` doesn't type-check `vite.config.ts` (it's outside `tsconfig`'s `include`). I verified under `vp lint`:

| plugins value | `vp lint` |
|---|---|
| `react()` | ❌ TS2321 |
| `[...react()]` (no cast) | ❌ TS2321 |
| `[...react()] as PluginOption[]` | ✅ clean |

So the cast isn't cosmetic — it's required for the lint gate to pass. A short comment in the file documents this so it isn't mistaken for a gratuitous cast and removed.

`PluginOption` is imported from `vite-plus` (it re-exports it via `export * from "@voidzero-dev/vite-plus-core"`), so no new dependency is added.

## Verification

After the change, `vp lint` reports no errors (only two pre-existing, unrelated `no-unused-vars` warnings remain in `Plugins.tsx`/`PluginsManager.tsx`).