### PR TITLE
fix(ui): reset body margin and prevent window overflow (#1035, #1036)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Grid from "@mui/material/Grid";
+import CssBaseline from "@mui/material/CssBaseline";
+import GlobalStyles from "@mui/material/GlobalStyles";
 import { useRoutes } from "react-router-dom";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 
@@ -45,6 +47,17 @@ function App() {
     <SparusErrorContext.Provider value={errorCache}>
       <StoreProvider>
         <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <GlobalStyles
+            styles={{
+              "html, body, #root": {
+                margin: 0,
+                padding: 0,
+                height: "100%",
+                overflow: "hidden",
+              },
+            }}
+          />
           <PluginManager>
             <Grid
               container


### PR DESCRIPTION
Fixes #1035 and #1036.

## Cause
There's no CSS reset, so the browser default `body { margin: 8px }` applies. In the fixed **800×600** decorationless window that 8px margin (a) shows the page background as a **white border** (#1036) and (b) pushes the 800×600 Grid ~16px past the window edge → **scrollbars** (#1035, the reported "~20px").

## Fix
Mount MUI `CssBaseline` + a small `GlobalStyles` that zeroes margin/padding and pins `html, body, #root` to `height: 100%` with `overflow: hidden`, so the launcher fills the window with no border or scrollbar.

`tsc --noEmit` and `vp lint` are clean. The visual result (no border/scrollbar) is runtime-only — please confirm in the running 800×600 window.