### PR TITLE
fix(ci): don't sign Android build on fork PRs (#1033)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    env:
+      ANDROID_KEY_BASE64: ${{ secrets.ANDROID_KEY_BASE64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -93,7 +95,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --manifest-path=src-tauri/Cargo.toml --all-targets -- -D warnings
       - name: setup Android signing
-        if: matrix.mobile == 'android'
+        if: matrix.mobile == 'android' && env.ANDROID_KEY_BASE64 != ''
         run: |
           cd src-tauri/gen/android
           echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -28,15 +28,19 @@ android {
     signingConfigs {
         create("release") {
             val keystorePropertiesFile = rootProject.file("keystore.properties")
-            val keystoreProperties = Properties()
+            // Only wire up signing when a keystore is present (e.g. push/internal
+            // builds). On fork PRs the secrets — and therefore the keystore — are
+            // absent, so the release build stays unsigned instead of crashing on a
+            // null `as String` cast.
             if (keystorePropertiesFile.exists()) {
+                val keystoreProperties = Properties()
                 keystoreProperties.load(FileInputStream(keystorePropertiesFile))
-            }
 
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["password"] as String
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["password"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["password"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["password"] as String
+            }
         }
     }
     buildTypes {
@@ -52,7 +56,9 @@ android {
             }
         }
         getByName("release") {
-            signingConfig = signingConfigs.getByName("release")
+            if (rootProject.file("keystore.properties").exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }


### PR DESCRIPTION
Fixes #1033.

## Cause
The **"setup Android signing"** step runs on every `pull_request` (`if: matrix.mobile == 'android'`). Fork PRs receive **empty secrets**, so it writes an empty `keystore.properties` and decodes an empty keystore → Gradle release signing fails (KeytoolException / null `as String` cast), breaking the Android job on every external PR.

## Fix
- **build.yml**: expose `ANDROID_KEY_BASE64` as a job-level env and gate the signing step on it being non-empty — pushes / internal PRs still sign, fork PRs skip it.
- **build.gradle.kts**: only attach the release `signingConfig` (and only read the keystore props) when `keystore.properties` exists, so an unsigned release build no longer crashes on a null cast.

Not locally verifiable (CI YAML + Gradle). Please confirm via a CI run that the Android job goes green (unsigned) on PRs and still produces a **signed** apk/aab on push/internal runs.