### PR TITLE
feat(plugins): render registered plugin slots + add an options target (#1034)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,7 @@ import SettingsIcon from "@mui/icons-material/Settings";
 
 // Components
 import { SparusErrorContext } from "utils/Context";
+import { PluginSlot } from "utils/usePlugins";
 
 // Tauri api
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -99,6 +100,7 @@ function Header() {
           <ClearIcon />
         </IconButton>
       </Grid>
+      <PluginSlot position="header" />
     </Grid>
   );
 }

--- a/src/components/Index.tsx
+++ b/src/components/Index.tsx
@@ -1,7 +1,13 @@
 import Footer from "components/Footer";
+import { PluginSlot } from "utils/usePlugins";
 
 function Index() {
-  return <Footer />;
+  return (
+    <>
+      <PluginSlot position="body" />
+      <Footer />
+    </>
+  );
 }
 
 export default Index;

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -9,6 +9,7 @@ import IconButton from "@mui/material/IconButton";
 
 // Components
 import { SparusErrorContext, SparusStoreContext } from "utils/Context";
+import { PluginSlot } from "utils/usePlugins";
 
 // Tauri api
 import { remove } from "@tauri-apps/plugin-fs";
@@ -183,6 +184,7 @@ function Options() {
         >
           <DeleteIcon />
         </IconButton>
+        <PluginSlot position="options" />
       </Grid>
     </Slide>
   );

--- a/src/utils/usePlugins.tsx
+++ b/src/utils/usePlugins.tsx
@@ -1,11 +1,12 @@
-import React, { createContext, useContext, useState, ReactElement } from "react";
+import React, { createContext, useContext, useState, Fragment, ReactElement } from "react";
 
-export type PluginPosition = "header" | "body" | "footer";
+export type PluginPosition = "header" | "body" | "footer" | "options";
 
 interface PluginContextType {
   header: ReactElement[];
   body: ReactElement[];
   footer: ReactElement[];
+  options: ReactElement[];
   register: (position: PluginPosition, element: ReactElement) => void;
   unregister: (position: PluginPosition, element: ReactElement) => void;
 }
@@ -15,21 +16,24 @@ export const PluginsProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const [header, setHeader] = useState<ReactElement[]>([]);
   const [body, setBody] = useState<ReactElement[]>([]);
   const [footer, setFooter] = useState<ReactElement[]>([]);
+  const [options, setOptions] = useState<ReactElement[]>([]);
 
   const register = (position: PluginPosition, element: ReactElement) => {
     if (position === "header") setHeader((prev) => [...prev, element]);
     if (position === "body") setBody((prev) => [...prev, element]);
     if (position === "footer") setFooter((prev) => [...prev, element]);
+    if (position === "options") setOptions((prev) => [...prev, element]);
   };
 
   const unregister = (position: PluginPosition, element: ReactElement) => {
     if (position === "header") setHeader((prev) => prev.filter((e) => e !== element));
     if (position === "body") setBody((prev) => prev.filter((e) => e !== element));
     if (position === "footer") setFooter((prev) => prev.filter((e) => e !== element));
+    if (position === "options") setOptions((prev) => prev.filter((e) => e !== element));
   };
 
   return (
-    <PluginsContext.Provider value={{ header, body, footer, register, unregister }}>
+    <PluginsContext.Provider value={{ header, body, footer, options, register, unregister }}>
       {children}
     </PluginsContext.Provider>
   );
@@ -41,4 +45,17 @@ export const usePluginsContext = (): PluginContextType => {
     throw new Error("usePluginsContext must be used inside a PluginsProvider");
   }
   return ctx;
+};
+
+// Renders every plugin element registered for a given position. Renders nothing
+// when no plugin targets the slot, so it is a safe drop-in anywhere in the UI.
+export const PluginSlot = ({ position }: { position: PluginPosition }): ReactElement => {
+  const elements = usePluginsContext()[position];
+  return (
+    <>
+      {elements.map((element, index) => (
+        <Fragment key={index}>{element}</Fragment>
+      ))}
+    </>
+  );
 };


### PR DESCRIPTION
Fixes #1034.

## Cause
The plugin context exposed `header`/`body`/`footer` arrays via `register()`, but **nothing rendered them**, so plugin elements were invisible — and there was no options target.

## Fix
- `usePlugins.tsx`: add an `options` position and export `<PluginSlot position>` that renders every element registered for a slot (renders nothing when empty → safe drop-in).
- Mount `<PluginSlot>` in the header (`Header.tsx`), body (`Index.tsx`) and options page (`Options.tsx`).

`tsc --noEmit` and `vp lint` are clean. Rendering is runtime-observable: in **dev** it works on its own; in **prod** plugins only appear once #1037 (the entry race) is also merged.

### Notes
- Independently fixes the two prior `no-unused-vars` warnings indirectly? No — those are unrelated; this PR is purely additive.
- Slots are currently **desktop-only** (`MobileIndex.tsx` renders no Header/Footer). Tell me if plugins should also show on mobile and I'll wire `MobileIndex`.
- The idea comes from your cloud session's branch (`claude/sparus-issues-0y9diz`), re-implemented on current `main` since that branch was based on a very old base and couldn't merge.