### PR TITLE
fix(plugins): isolate each plugin's MF remote name (#1042)

### DIFF
--- a/src/components/Plugins.tsx
+++ b/src/components/Plugins.tsx
@@ -3,8 +3,7 @@ import { useState, useEffect, useContext, ReactElement, ComponentType } from "re
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { SparusErrorContext } from "utils/Context";
-
-type PluginPosition = "header" | "body" | "footer";
+import type { PluginPosition } from "utils/usePlugins";
 
 type PluginsManagerProps = {
   path: string;
@@ -31,15 +30,21 @@ export const Plugins = ({ path, register, mf }: PluginsManagerProps & { mf: Modu
   useEffect(() => {
     let cancelled = false;
 
+    // Give each plugin its own host-local remote name so multiple installed
+    // plugins don't clobber a single shared "button" remote and render the same
+    // component several times (#1042). The exposed key ("Button") is unchanged,
+    // so plugin bundles don't need rebuilding.
+    const remoteName = `plugin_${path.replace(/[^a-zA-Z0-9_]/g, "_")}`;
+
     const loadPlugin = (entry: string) => {
       // Cache-bust the bundle URL so an updated frontend.js is fetched fresh
       // instead of served stale from the webview cache (#1037). `force` lets the
       // new entry replace a previously-registered remote of the same name.
       const versionedEntry = `${entry}?v=${Date.now()}`;
-      mf.registerRemotes([{ name: "button", type: "module", entry: versionedEntry }], {
+      mf.registerRemotes([{ name: remoteName, type: "module", entry: versionedEntry }], {
         force: true,
       });
-      mf.loadRemote(`button/Button`)
+      mf.loadRemote(`${remoteName}/Button`)
         .then((mod: unknown) => {
           if (cancelled) return;
           if (!isRemoteModule(mod)) {


### PR DESCRIPTION
## Scope (narrowed after 952ebd9)

Your commit 952ebd9 landed the registry-side fix for #1042 (memoized `register`/`unregister` + dedup in `usePlugins.tsx`), so I dropped that half from this PR. What remains is the **loader-side half** of #1042, still present on `main`:

## Problem

Every `<Plugins>` instance registers its bundle under the **single shared remote name** `"button"` with `force: true`, and loads `button/Button`. With several plugins installed, each registration clobbers the previous one, so every `loadRemote("button/Button")` resolves to the **last-registered bundle** — you get N copies of one plugin instead of N distinct plugins. The registry dedup then collapses those copies, so the visible symptom is gone, but distinct plugins still can't coexist.

## Fix

Derive a host-local remote name from the plugin path (`plugin_<sanitized path>`), so each plugin gets its own MF remote:

```ts
const remoteName = `plugin_${path.replace(/[^a-zA-Z0-9_]/g, "_")}`;
```

- The exposed key (`./Button`) is unchanged → **no plugin rebuild needed**.
- Also reuses the `PluginPosition` type exported by `usePlugins` instead of a stale local 3-position copy.

One file, +9/−4. `tsc` and `vp lint` clean.