### PR TITLE
fix(plugins): read import.meta.env.DEV directly instead of stale state

### DIFF
--- a/src/components/PluginsManager.tsx
+++ b/src/components/PluginsManager.tsx
@@ -6,17 +6,17 @@ import { PluginsProvider, usePluginsContext } from "utils/usePlugins";
 import { SparusErrorContext } from "utils/Context";
 import { Plugins } from "components/Plugins";
 
+const isDev = import.meta.env.DEV;
+
 const PluginLoader: React.FC = () => {
   const [pluginPath, setPluginsPath] = useState<string[]>([]);
   const [mf, setMF] = useState<ModuleFederation>();
-  const [dev, setDev] = useState<boolean>(false);
   const { register } = usePluginsContext();
 
   const { setGlobalError } = useContext(SparusErrorContext);
 
   useEffect(() => {
-    setDev(import.meta.env.DEV);
-    if (!dev) {
+    if (!isDev) {
       invoke<string[]>("js_plugins_path")
         .then((path) => setPluginsPath(path))
         .catch((err) => setGlobalError(err));
@@ -54,7 +54,7 @@ const PluginLoader: React.FC = () => {
   if (!mf) return null;
   return (
     <div style={{ display: "none" }}>
-      {!dev ? (
+      {!isDev ? (
         pluginPath.map((path) => <Plugins key={path} path={path} register={register} mf={mf} />)
       ) : (
         <Plugins path="sparus" register={register} mf={mf} />


### PR DESCRIPTION
Small cleanup found while investigating #1042 (not a functional bug, but a latent inconsistency).

`PluginLoader` stored dev mode in state and set it **inside** the mount effect (`setDev(import.meta.env.DEV)`), then read the still-`false` `dev` in the same effect — so in dev mode it needlessly called `js_plugins_path` (a disk scan) on the first pass before the state flush switched the render branch.

`import.meta.env.DEV` is a Vite compile-time constant, so read it directly as a module-level `isDev`. Drops the redundant `useState` and the extra render.

`tsc --noEmit` and `vp lint` are clean.