### PR TITLE
fix(android): stop tracking keystore.properties so fork PRs build

### DIFF
--- a/src-tauri/gen/android/.gitignore
+++ b/src-tauri/gen/android/.gitignore
@@ -14,6 +14,7 @@ build
 .cxx
 local.properties
 key.properties
+keystore.properties
 
 /.tauri
 /tauri.settings.gradle

--- a/src-tauri/gen/android/keystore.properties
+++ b/src-tauri/gen/android/keystore.properties
@@ -1,3 +1,0 @@
-password=SparusLudea12!
-keyAlias=sparus
-storeFile=C:\\Users\\Ludovic\\sparus-keystore.jks


### PR DESCRIPTION
## Problem

The Android build fails on every **fork PR** (e.g. #1045) with:

```
* Where: src-tauri/gen/android/app/build.gradle.kts line: 41
* What went wrong:
java.net.URISyntaxException: Illegal character in opaque part at index 2:
    C:\Users\...\sparus-keystore.jks
```

`src-tauri/gen/android/keystore.properties` is **committed** to the repo and points `storeFile` at a hard-coded Windows path. `.gitignore` ignores `key.properties` but not `keystore.properties`, so the file was tracked since `66d8e64`.

- On **push** builds the `ANDROID_KEY_BASE64` secret exists, so the *setup Android signing* step overwrites `keystore.properties` with a valid `$RUNNER_TEMP/keystore.jks` path → build passes.
- On **fork PRs** the secret is unavailable, so that step is skipped and the committed file is used as-is. Gradle's `file("C:\...")` parses the drive-letter `:` as a URI and throws → the Android job fails on every fork PR (all other platforms are green).

## Fix

- `git rm --cached` the committed `keystore.properties`
- add `keystore.properties` to `src-tauri/gen/android/.gitignore`

**Push builds are unaffected** — the signing step still writes a fresh `keystore.properties` from secrets. On fork PRs there is now no keystore, so the existing `if (keystorePropertiesFile.exists())` guard (from #1039) leaves the release build unsigned instead of crashing. No change to `build.gradle.kts`.

## ⚠️ Security note

The tracked file contained the signing **password in plaintext**. The `.jks` keystore itself was never in the repo, so the signing key is **not** compromised, but since the password sat in public git history I'd recommend rotating it as a precaution (and optionally purging it from history).