### PR TITLE
feat(plugins): let a plugin set coords inside its slot (#1044)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The frontend is built with **React 19** + **MUI v9**, while the backend is writt
 
 ## Ecosystem
 
-[Lucle](https://github.com/ludea/lucle), a cms with an admin dashboard to manage binaries versions 
+[Lucle](https://github.com/ludea/lucle), a cms with an admin dashboard to manage binaries versions
 
 ## Features
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -19,6 +19,7 @@ import ErrorIcon from "@mui/icons-material/WarningRounded";
 
 // Context
 import { SparusErrorContext, SparusStoreContext } from "utils/Context";
+import { PluginSlot } from "utils/usePlugins";
 
 // Tauri api
 import { invoke } from "@tauri-apps/api/core";
@@ -461,6 +462,8 @@ function Footer() {
           </Paper>
         </Grid>
       ) : null}
+      {/* The root Grid is position: fixed, so plugin coords anchor to the footer area */}
+      <PluginSlot position="footer" />
     </Grid>
   );
 }

--- a/src/components/Index.tsx
+++ b/src/components/Index.tsx
@@ -1,10 +1,14 @@
+import Box from "@mui/material/Box";
 import Footer from "components/Footer";
 import { PluginSlot } from "utils/usePlugins";
 
 function Index() {
   return (
     <>
-      <PluginSlot position="body" />
+      {/* Positioned container: plugin coords are offsets inside the body area */}
+      <Box sx={{ position: "relative", width: "100%", height: "100%" }}>
+        <PluginSlot position="body" />
+      </Box>
       <Footer />
     </>
   );

--- a/src/components/Plugins.tsx
+++ b/src/components/Plugins.tsx
@@ -1,18 +1,17 @@
 import { ModuleFederation } from "@module-federation/runtime";
-import { useState, useEffect, useContext, ReactElement, ComponentType } from "react";
+import { useState, useEffect, useContext, ComponentType } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { SparusErrorContext } from "utils/Context";
-
-type PluginPosition = "header" | "body" | "footer";
+import type { RegisterPluginFn } from "utils/usePlugins";
 
 type PluginsManagerProps = {
   path: string;
-  register: (pos: PluginPosition, el: ReactElement) => void;
+  register: RegisterPluginFn;
 };
 
 type PluginsProps = {
-  register: (pos: PluginPosition, el: ReactElement) => void;
+  register: RegisterPluginFn;
   setError: (err: unknown) => void;
 };
 

--- a/src/utils/usePlugins.tsx
+++ b/src/utils/usePlugins.tsx
@@ -12,44 +12,67 @@ import {
 
 export type PluginPosition = "header" | "body" | "footer" | "options";
 
+// CSS lengths: a number is treated as px, a string is used as-is (e.g. "10%").
+export type PluginCoords = {
+  x: number | string;
+  y: number | string;
+};
+
+export type RegisterPluginFn = (
+  position: PluginPosition,
+  element: ReactElement,
+  coords?: PluginCoords,
+) => void;
+
+type PluginEntry = {
+  element: ReactElement;
+  coords?: PluginCoords;
+};
+
 interface PluginContextType {
-  header: ReactElement[];
-  body: ReactElement[];
-  footer: ReactElement[];
-  options: ReactElement[];
-  register: (position: PluginPosition, element: ReactElement) => void;
+  header: PluginEntry[];
+  body: PluginEntry[];
+  footer: PluginEntry[];
+  options: PluginEntry[];
+  register: RegisterPluginFn;
   unregister: (position: PluginPosition, element: ReactElement) => void;
 }
 const PluginsContext = createContext<PluginContextType | null>(null);
 
-const addPluginElement = (elements: ReactElement[], element: ReactElement) => {
-  const alreadyRegistered = elements.some(
-    (registered) => registered.key === element.key && registered.type === element.type,
+const addPluginEntry = (entries: PluginEntry[], entry: PluginEntry) => {
+  const alreadyRegistered = entries.some(
+    (registered) =>
+      registered.element.key === entry.element.key &&
+      registered.element.type === entry.element.type,
   );
 
-  if (alreadyRegistered) return elements;
+  if (alreadyRegistered) return entries;
 
-  return [...elements, element];
+  return [...entries, entry];
 };
 
 export const PluginsProvider: FC<{ children: ReactNode }> = ({ children }) => {
-  const [header, setHeader] = useState<ReactElement[]>([]);
-  const [body, setBody] = useState<ReactElement[]>([]);
-  const [footer, setFooter] = useState<ReactElement[]>([]);
-  const [options, setOptions] = useState<ReactElement[]>([]);
+  const [header, setHeader] = useState<PluginEntry[]>([]);
+  const [body, setBody] = useState<PluginEntry[]>([]);
+  const [footer, setFooter] = useState<PluginEntry[]>([]);
+  const [options, setOptions] = useState<PluginEntry[]>([]);
 
-  const register = useCallback((position: PluginPosition, element: ReactElement) => {
-    if (position === "header") setHeader((prev) => addPluginElement(prev, element));
-    if (position === "body") setBody((prev) => addPluginElement(prev, element));
-    if (position === "footer") setFooter((prev) => addPluginElement(prev, element));
-    if (position === "options") setOptions((prev) => addPluginElement(prev, element));
-  }, []);
+  const register = useCallback(
+    (position: PluginPosition, element: ReactElement, coords?: PluginCoords) => {
+      const entry = { element, coords };
+      if (position === "header") setHeader((prev) => addPluginEntry(prev, entry));
+      if (position === "body") setBody((prev) => addPluginEntry(prev, entry));
+      if (position === "footer") setFooter((prev) => addPluginEntry(prev, entry));
+      if (position === "options") setOptions((prev) => addPluginEntry(prev, entry));
+    },
+    [],
+  );
 
   const unregister = useCallback((position: PluginPosition, element: ReactElement) => {
-    if (position === "header") setHeader((prev) => prev.filter((e) => e !== element));
-    if (position === "body") setBody((prev) => prev.filter((e) => e !== element));
-    if (position === "footer") setFooter((prev) => prev.filter((e) => e !== element));
-    if (position === "options") setOptions((prev) => prev.filter((e) => e !== element));
+    if (position === "header") setHeader((prev) => prev.filter((e) => e.element !== element));
+    if (position === "body") setBody((prev) => prev.filter((e) => e.element !== element));
+    if (position === "footer") setFooter((prev) => prev.filter((e) => e.element !== element));
+    if (position === "options") setOptions((prev) => prev.filter((e) => e.element !== element));
   }, []);
 
   const value = useMemo(
@@ -69,12 +92,23 @@ export const usePluginsContext = (): PluginContextType => {
 };
 
 export const PluginSlot = ({ position }: { position: PluginPosition }): ReactElement => {
-  const elements = usePluginsContext()[position];
+  const entries = usePluginsContext()[position];
   return (
     <>
-      {elements.map((element, index) => (
-        <Fragment key={index}>{element}</Fragment>
-      ))}
+      {entries.map((entry, index) =>
+        entry.coords ? (
+          // Anchored to the slot area: the slot's container is the nearest
+          // positioned ancestor (relative/fixed), so x/y are offsets inside it.
+          <div
+            key={index}
+            style={{ position: "absolute", left: entry.coords.x, top: entry.coords.y }}
+          >
+            {entry.element}
+          </div>
+        ) : (
+          <Fragment key={index}>{entry.element}</Fragment>
+        ),
+      )}
     </>
   );
 };


### PR DESCRIPTION
Closes #1044 — following your comment that position means *coords inside "body" or "footer"*.

## What this adds

`register()` gains an **optional** third argument:

```ts
register(position, element, coords?: { x: number | string; y: number | string })
```

- **With coords** → the element renders absolutely positioned at `(x, y)` inside its slot area. A number is px, a string is any CSS length (`"10%"`, `"2rem"`, …).
- **Without coords** → exactly today's in-flow behavior. **Existing plugins keep working unchanged.**

Example from a plugin:

```tsx
register("body", <MyWidget />, { x: 40, y: "20%" });
register("footer", <StatusBadge />, { x: "80%", y: 0 });
```

## Anchoring

- **body**: the slot is wrapped in a `position: relative` container in `Index.tsx`, so coords are offsets from the body area's top-left.
- **footer**: `<PluginSlot position="footer" />` is now mounted inside Footer's fixed root Grid (`footer` was in the position enum but no slot was rendered anywhere) — coords anchor to the footer area.

## Notes

- `Plugins.tsx` reuses the shared `RegisterPluginFn` type so remote bundles see the new signature (and can also target `options`, which the local type copy didn't include).
- 4 files, +74/−34. `tsc` and `vp lint` clean.
- If by "coords" you had something else in mind (grid cells, anchor presets like top-left/center…), say the word and I'll adjust — the registry shape supports swapping the placement semantics without touching the plugin ABI again.