### PR TITLE
fix: strip trailing whitespace in README so vp check passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The frontend is built with **React 19** + **MUI v9**, while the backend is writt
 
 ## Ecosystem
 
-[Lucle](https://github.com/ludea/lucle), a cms with an admin dashboard to manage binaries versions 
+[Lucle](https://github.com/ludea/lucle), a cms with an admin dashboard to manage binaries versions
 
 ## Features
 


### PR DESCRIPTION
6814094 (add lucle into ecosystem) left a trailing space at the end of the Lucle line, and `vp run check` (oxfmt) fails on it — so the **Lint and prettier step is currently red on every PR**, e.g. #1049.

One character removed. `vp run check` passes locally after this.